### PR TITLE
RLPH-866

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -58,6 +58,14 @@ class ThinkingSphinx::Deltas::DelayedDelta <
     end
   end
 
+  def toggle(instance)
+    # TODO: consider adding the set_delta_flag? method as a configurable value.  LMC
+    if !instance.respond_to?(:set_delta_flag?) || instance.set_delta_flag?
+      instance.send "#{column}=", true
+    end
+  end
+
+
   module Binary
     # Adds a job to the queue for processing the given model's delta index. A job
     # for hiding the instance in the core index is also created, if an instance is

--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -40,9 +40,9 @@ class ThinkingSphinx::Deltas::DelayedDelta <
       # Only priority option is supported for these versions
       ThinkingSphinx::Configuration.instance.delayed_job_priority || 0
     else
-      {
-        :priority => job_option(:delayed_job_priority, 0),
-        :queue    => job_option(:delayed_job_queue)
+      { priority: job_option(:delayed_job_priority, 0),
+        queue: job_option(:delayed_job_queue),
+        run_at: job_option(:delta_delay, 0).to_i.seconds.from_now
       }
     end
   end


### PR DESCRIPTION
- added support for a `delta_delay` option (set it in your thinking_sphinx.yml config) which specifies the number of seconds to delay before firing the Delta update.  This should cause any additional Delta indexing jobs to be batched together and fired as a single batch of Delta updates.
- added support for an optional `set_delta_flag?` method on indexed objects.  If present on the instance delta indexing will only be triggered for that instance if the set_delta_flag? method returns true.  If not present delta indexing will be triggered for that instance every time the object is saved.
