### PR TITLE
ts-delayed-delta v2.0.2.1

### DIFF
--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -58,6 +58,14 @@ class ThinkingSphinx::Deltas::DelayedDelta <
     end
   end
 
+  def toggle(instance)
+    # TODO: consider adding the set_delta_flag? method as a configurable value.  LMC
+    if !instance.respond_to?(:set_delta_flag?) || instance.set_delta_flag?
+      instance.send "#{column}=", true
+    end
+  end
+
+
   module Binary
     # Adds a job to the queue for processing the given model's delta index. A job
     # for hiding the instance in the core index is also created, if an instance is

--- a/lib/thinking_sphinx/deltas/delayed_delta.rb
+++ b/lib/thinking_sphinx/deltas/delayed_delta.rb
@@ -40,9 +40,9 @@ class ThinkingSphinx::Deltas::DelayedDelta <
       # Only priority option is supported for these versions
       ThinkingSphinx::Configuration.instance.delayed_job_priority || 0
     else
-      {
-        :priority => job_option(:delayed_job_priority, 0),
-        :queue    => job_option(:delayed_job_queue)
+      { priority: job_option(:delayed_job_priority, 0),
+        queue: job_option(:delayed_job_queue),
+        run_at: job_option(:delta_delay, 0).to_i.seconds.from_now
       }
     end
   end

--- a/ts-delayed-delta.gemspec
+++ b/ts-delayed-delta.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'ts-delayed-delta'
-  s.version     = '2.0.2'
+  s.version     = '2.0.2.1'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Pat Allan']
   s.email       = ['pat@freelancing-gods.com']


### PR DESCRIPTION
Changes to allow for better control over how often Delta jobs get run and controls to allow validation on whether the changes made to an instance warrant a Delta indexing update.
